### PR TITLE
修复使用内网地址(http)请求时会出现签名错误的bug

### DIFF
--- a/src/sign.ts
+++ b/src/sign.ts
@@ -9,7 +9,7 @@ export class Signature {
   ) {
     const url = `${host}${path}`;
     const paramStr = this.makeParamStr(params);
-    return `${method}${url.replace(/^https:\/\//i, '')}${paramStr}`;
+    return `${method}${url.replace(/^(https|http):\/\//i, '')}${paramStr}`;
   }
 
   public static sign(text: string, secretKey: string, signMethod = 'HmacSHA1') {


### PR DESCRIPTION
签名代码中提取域名的正则中只有https，需要添加http来支持内网访问
否则使用内网地址访问时会提示签名错误